### PR TITLE
Fix for dying when no selection in view.sel()

### DIFF
--- a/perlidx.py
+++ b/perlidx.py
@@ -12,7 +12,11 @@ def DisplayCurrentSub(view, subs, index, pos):
             view.set_status('perlsubs', '[PerlSub: <none>]')
 
 def GetCurrentSub(view, subs):
-    pos = view.sel()[0].a
+    selection = view.sel()
+    if not selection:
+        pos = 0
+    else:
+        pos = selection[0].a
     index = -1
     if 'last' in views[view.id()]:
         cache = views[view.id()]['last']


### PR DESCRIPTION
Traceback (most recent call last):
  File "~/Library/Application Support/Sublime Text/Packages/PerlSubs/perlidx.py", line 109, in func
    return deferred_get_list(view, t)
  File "~/Library/Application Support/Sublime Text/Packages/PerlSubs/perlidx.py", line 87, in deferred_get_list
    GetCurrentSub(view, subs)
  File "~/Library/Application Support/Sublime Text/Packages/PerlSubs/perlidx.py", line 20, in GetCurrentSub
    pos = view.sel()[0].a
  File "/Applications/Sublime Text.app/Contents/MacOS/Lib/python33/sublime.py", line 1072, in __getitem__
    raise IndexError()
IndexError